### PR TITLE
Flip `K.sr` and `K.sl`

### DIFF
--- a/3DSage_Starter.c
+++ b/3DSage_Starter.c
@@ -54,8 +54,8 @@ void movePlayer()
  if(K.w ==1 && K.m==0){ printf("up\n");}
  if(K.s ==1 && K.m==0){ printf("down\n");}
  //strafe left, right
- if(K.sr==1){ printf("strafe left\n");}
- if(K.sl==1){ printf("strafe right\n");}
+ if(K.sl==1){ printf("strafe left\n");}
+ if(K.sr==1){ printf("strafe right\n");}
  //move up, down, look up, look down
  if(K.a==1 && K.m==1){ printf("look up\n");}
  if(K.d==1 && K.m==1){ printf("look down\n");}


### PR DESCRIPTION
`K.sr` and `K.sl` are out of order (where `K.a` and `K.d` are left then right, as are the printed comments on the strafe command). This leads to a flip of the left and right strafe on key press.

This updates the order of the variables so that the proper key-press moves the world in the correct direction. 